### PR TITLE
Update gradle build to publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.17.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -29,6 +30,12 @@ allprojects {
 
         // Needed for Dokka
         jcenter()
+    }
+
+    plugins.withId("com.vanniktech.maven.publish") {
+        mavenPublish {
+            sonatypeHost = "S01"
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,34 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 org.gradle.configureondemand=true
+
+GROUP=au.com.woolworths.village.sdk
+POM_ARTIFACT_ID=api-sdk
+VERSION_NAME=4.0.1
+
+POM_NAME=WPay Android API SDK
+POM_DESCRIPTION=Android SDK for using WPay API
+POM_URL=https://github.com/w-pay/sdk-wpay-android
+
+POM_LICENSE_NAME=WPAY Software Development Kit Licence
+POM_LICENSE_URL=https://github.com/w-pay/sdk-wpay-android/blob/master/LICENSE.md
+POM_LICENSE_DIST=repo
+
+POM_SCM_URL=https://github.com/w-pay/sdk-wpay-android
+POM_SCM_CONNECTION=scm:git:git://github.com/w-pay/sdk-wpay-android.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://github.com:w-pay/sdk-wpay-android.git
+
+POM_DEVELOPER_ID=username
+POM_DEVELOPER_NAME=User Name
+POM_DEVELOPER_URL=https://github.com/username/
+
+#
+# Placeholders.
+#
+# To define real values, use the -P option to gradle.
+mavenCentralUsername = ""
+mavenCentralPassword = ""
+
+signing.keyId=""
+signing.password=""
+signing.secretKeyRingFile=""

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 org.gradle.configureondemand=true
 
-GROUP=au.com.woolworths.village.sdk
+GROUP=au.com.wpay.village.sdk
 POM_ARTIFACT_ID=api-sdk
 VERSION_NAME=4.0.1
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,11 +1,13 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'maven' // Required for publishing to packagecloud
 apply plugin: "org.jetbrains.dokka"
 
-group "au.com.woolworths.village.sdk"
-version "4.0.1"
+// handle signing/publishing AARs for us
+// gradle's default maven-publish doesn't handle AARs very well
+apply plugin: "com.vanniktech.maven.publish"
+
+// for project coordinates (group, version, etc) see gradle.properties
 
 android {
     compileSdkVersion rootProject.ext.targetSdkVersion
@@ -27,10 +29,6 @@ android {
     }
 }
 
-configurations {
-    deployerJars
-}
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
@@ -44,20 +42,6 @@ dependencies {
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-
-    deployerJars "io.packagecloud.maven.wagon:maven-packagecloud-wagon:0.0.6"
-}
-
-uploadArchives {
-    repositories.mavenDeployer {
-        configuration = configurations.deployerJars
-        repository(url: "packagecloud+https://packagecloud.io/woolworths/paysdk2") {
-            authentication(password: System.getenv('PACKAGECLOUD_TOKEN'))
-        }
-        pom.groupId = project.group
-        pom.version = project.version
-        pom.artifactId = project.getName()
-    }
 }
 
 dokkaHtml {


### PR DESCRIPTION
This updates the Gradle build with the necessary steps to publish to OSSHR Nexus for #5 

I've tested the signing step of the build using a dummy GPG key.

The major impact to consumers is the changing of the `groupId` to be `au.com.wpay`.