### PR TITLE
Roll back changes to fix build process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.17.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -30,12 +29,6 @@ allprojects {
 
         // Needed for Dokka
         jcenter()
-    }
-
-    plugins.withId("com.vanniktech.maven.publish") {
-        mavenPublish {
-            sonatypeHost = "S01"
-        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,34 +21,3 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 org.gradle.configureondemand=true
-
-GROUP=au.com.wpay.village.sdk
-POM_ARTIFACT_ID=api-sdk
-VERSION_NAME=4.4.0
-
-POM_NAME=WPay Android API SDK
-POM_DESCRIPTION=Android SDK for using WPay API
-POM_URL=https://github.com/w-pay/sdk-wpay-android
-
-POM_LICENSE_NAME=WPAY Software Development Kit Licence
-POM_LICENSE_URL=https://github.com/w-pay/sdk-wpay-android/blob/master/LICENSE.md
-POM_LICENSE_DIST=repo
-
-POM_SCM_URL=https://github.com/w-pay/sdk-wpay-android
-POM_SCM_CONNECTION=scm:git:git://github.com/w-pay/sdk-wpay-android.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://github.com:w-pay/sdk-wpay-android.git
-
-POM_DEVELOPER_ID=username
-POM_DEVELOPER_NAME=User Name
-POM_DEVELOPER_URL=https://github.com/username/
-
-#
-# Placeholders.
-#
-# To define real values, use the -P option to gradle.
-mavenCentralUsername = ""
-mavenCentralPassword = ""
-
-signing.keyId=""
-signing.password=""
-signing.secretKeyRingFile=""

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -3,12 +3,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: "org.jetbrains.dokka"
 
-// handle signing/publishing AARs for us
-// gradle's default maven-publish doesn't handle AARs very well
-apply plugin: "com.vanniktech.maven.publish"
-
-// for project coordinates (group, version, etc) see gradle.properties
-
 android {
     compileSdkVersion rootProject.ext.targetSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion


### PR DESCRIPTION
Reverting changes made in this issue: https://github.com/w-pay/sdk-wpay-android/issues/5

Why do we need these changes?
Currently the build process is broken from CI: https://jitpack.io/com/github/w-pay/sdk-wpay-android/v4.3.1/build.log