### PR TITLE
Fix CI by adding missing maven-publish plugin

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -3,6 +3,7 @@ apply plugin: "kotlin-android"
 apply plugin: "kotlin-android-extensions"
 apply plugin: "org.jetbrains.dokka"
 apply plugin: "de.mannodermaus.android-junit5"
+apply plugin: 'maven-publish'
 
 android {
     compileSdkVersion rootProject.ext.targetSdkVersion


### PR DESCRIPTION
[Fix CI](https://github.com/w-pay/sdk-wpay-android/issues/5) by adding missing maven-publish plugin.

Why do we need these changes?
Currently the build process is broken from CI: https://jitpack.io/com/github/w-pay/sdk-wpay-android/v4.4.1/build.log