### PR TITLE
Define publication in Gradle to fix issue in CI not finding artifacts

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -38,9 +38,9 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
-                groupId = 'au.com.wpay.village.sdk'
+                groupId = group
                 artifactId = 'api-sdk'
-                version = '4.4.3'
+                version = version
             }
         }
     }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -25,6 +25,24 @@ android {
     }
 }
 
+task sourceJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier "sources"
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+                groupId = 'au.com.wpay.village.sdk'
+                artifactId = 'api-sdk'
+                version = '4.4.3'
+            }
+        }
+    }
+}
+
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -5,6 +5,9 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: "de.mannodermaus.android-junit5"
 apply plugin: 'maven-publish'
 
+group = 'au.com.wpay.village.sdk'
+version = '4.4.3'
+
 android {
     compileSdkVersion rootProject.ext.targetSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
@@ -35,9 +38,9 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
-                groupId = 'au.com.wpay.village.sdk'
+                groupId = group
                 artifactId = 'api-sdk'
-                version = '4.4.3'
+                version = version
             }
         }
     }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -38,9 +38,9 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
-                groupId = group
+                groupId = 'au.com.wpay.village.sdk'
                 artifactId = 'api-sdk'
-                version = version
+                version = '4.4.3'
             }
         }
     }


### PR DESCRIPTION
[Fix CI](https://github.com/w-pay/sdk-wpay-android/issues/5) by defining publications in Gradle file.

**Why do we need these changes?**
Currently the publish process is broken from CI: https://jitpack.io/com/github/w-pay/sdk-wpay-android/v4.4.2/build.log

Logs are showing ERROR: No build artifacts found. 

This PR solves that issue by defining publications following the [example from Jitpack](https://github.com/jitpack/android-example/blob/master/library/build.gradle)